### PR TITLE
Install dep bug

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: install dependencies
   yum:
     name: "{{ item }}"
-    state: present
+    state: latest
     update_cache: true
   with_items: keepalived_dependencies
   when: ansible_os_family == 'RedHat'
@@ -16,7 +16,7 @@
 - name: install dependencies
   apt:
     name: "{{ item }}"
-    state: present
+    state: latest
     force: yes
     update_cache: true
     cache_valid_time: 3600

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,8 @@
 - name: install dependencies
   apt:
     name: "{{ item }}"
-    state: latest
+    state: present
+    force: yes
     update_cache: true
     cache_valid_time: 3600
   with_items: keepalived_dependencies


### PR DESCRIPTION
Got this:

```
TASK: [keepalived | install dependencies] ************************************* 
failed: [192.168.42.51] => (item=keepalived) => {"failed": true, "item": "keepalived"}
stderr: E: There are problems and -y was used without --force-yes

stdout: Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  iproute ipvsadm libperl5.18 libsensors4 libsnmp-base libsnmp30
Suggested packages:
  heartbeat ldirectord lm-sensors snmp-mibs-downloader
The following NEW packages will be installed:
  iproute ipvsadm keepalived libperl5.18 libsensors4 libsnmp-base libsnmp30
0 upgraded, 7 newly installed, 0 to remove and 46 not upgraded.
Need to get 1221 kB of archives.
After this operation, 4728 kB of additional disk space will be used.
WARNING: The following packages cannot be authenticated!
  libsensors4 libperl5.18 ipvsadm keepalived

msg: '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"   install 'keepalived'' failed: E: There are problems and -y was used without --force-yes
```
