### PR TITLE
Made authentication optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Set up the latest or a specific version of [Keepalived](http://www.keepalived.or
 * `keepalived_vrrp_instances.key.virtual_router_id`: Arbitrary unique number (`0...255`) used to differentiate multiple instances of VRRPD running on the same NIC (and hence same socket)
 * `keepalived_vrrp_instances.key.advert_int`: [optional]: The advert interval in seconds
 * `keepalived_vrrp_instances.key.smtp_alert`: [optional]: Whether or not to send email notifications during state transitioning-
-* `keepalived_vrrp_instances.key.authentication`: Authentication block
+* `keepalived_vrrp_instances.key.authentication`: [optional]: Authentication block
 * `keepalived_vrrp_instances.key.authentication.auth_type`: Simple password or IPSEC AH (`PASS|AH`)
 * `keepalived_vrrp_instances.key.authentication.auth_pass`: Password string (up to 8 characters)
 * `keepalived_vrrp_instances.key.virtual_ipaddresses`: VRRP IP address block

--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -56,10 +56,12 @@ vrrp_instance {{ key }} {
   smtp_alert
 {% endif %}
 
+{% if value.authentication is defined %}
   authentication {
     auth_type {{ value.authentication.auth_type }}
     auth_pass {{ value.authentication.auth_pass }}
   }
+{% endif %}
 
   virtual_ipaddress {
 {% for virtual_ipaddress in value.virtual_ipaddresses %}


### PR DESCRIPTION
As reported in *keepalived.conf* manpage, using VRRP authentication is not recommended:

> Note: authentication was removed from the VRRPv2 specification by RFC3768 in 2004. Use of this option is non-compliant and can cause problems; avoid using if possible, except when using unicast, where it can be helpful.

I made authentication-related variables optional (instead of required).
