### PR TITLE
implement virtual_ipaddress_excluded block to support more than 20 ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Set up the latest or a specific version of [Keepalived](http://www.keepalived.or
 * `keepalived_vrrp_instances.key.authentication.auth_type`: Simple password or IPSEC AH (`PASS|AH`)
 * `keepalived_vrrp_instances.key.authentication.auth_pass`: Password string (up to 8 characters)
 * `keepalived_vrrp_instances.key.virtual_ipaddresses`: VRRP IP address block
+* `keepalived_vrrp_instances.key.virtual_ipaddresses_excluded`: IP address block, which is not included in the VRRP packet itself, in order to support more than 20 ips
 * `keepalived_vrrp_instances.key.nopreempt`: [optional]: VRRP will normally preempt a lower priority machine when a higher priority machine comes online. This option allows the lower priority machine to maintain the master role, even when a higher priority machine comes back online. **NOTE:** For this to work, the initial state of this entry must be `BACKUP`
 * `keepalived_vrrp_instances.key.preempt_delay`: [optional]: Seconds after startup until preemption (if not disabled by `nopreempt`). Range: 0 (default) to 1000 **NOTE:** For this to work, the initial state of this entry must be BACKUP
 * `keepalived_vrrp_instances.key.track_scripts`: Scripts state we monitor

--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -67,6 +67,14 @@ vrrp_instance {{ key }} {
 {% endfor %}
   }
 
+{% if value.virtual_ipaddresses_excluded | d([]) | length %}
+  virtual_ipaddress_excluded {
+{% for virtual_ipaddress in value.virtual_ipaddresses_excluded %}
+    {{ virtual_ipaddress }}
+{% endfor %}
+  }
+
+{% endif %}
 {% if value.nopreempt is defined and value.nopreempt | bool %}
   nopreempt
 {% endif %}


### PR DESCRIPTION
concerning the [official documentation](http://www.keepalived.org/doc/configuration_synopsis.html), the virtual_ipaddress block is limited to 20 IP addresses.