### PR TITLE
keep the list of virtual_upaddresses and virtual_ipaddresses_excluded order consistent

### DIFF
--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -64,14 +64,14 @@ vrrp_instance {{ key }} {
 {% endif %}
 
   virtual_ipaddress {
-{% for virtual_ipaddress in value.virtual_ipaddresses %}
+{% for virtual_ipaddress in value.virtual_ipaddresses | sort %}
     {{ virtual_ipaddress }}
 {% endfor %}
   }
 
 {% if value.virtual_ipaddresses_excluded is defined %}
   virtual_ipaddress_excluded {
-{% for virtual_ipaddress in value.virtual_ipaddresses_excluded | default([]) %}
+{% for virtual_ipaddress in value.virtual_ipaddresses_excluded | default([]) | sort %}
     {{ virtual_ipaddress }}
 {% endfor %}
   }


### PR DESCRIPTION
sort the list of virtual_ipaddresses and virtual_ipaddresses_excluded in order to keep the config idempotent