### PR TITLE
adding raw parameter support for global_defs and vrrp_instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Set up the latest or a specific version of [Keepalived](http://www.keepalived.or
 * `keepalived_global_defs_smtp_connect_timeout`: [default: `30`]: SMTP server connect timeout in seconds
 * `keepalived_global_defs_script_user`: [optional]: Specify the default user / group to run scripts under. If group is not specified, the group of the user is used. If this option is not specified, the user defaults to `keepalived_script`. If that user exists, otherwise `root` (since `1.3.0`, e.g. `'nobody nogroup'`, )
 * `keepalived_global_defs_enable_script_security`: [optional]: Don't run scripts configured to be run as `root` if any part of the path is writable by a `non-root` user (since `1.3.0`, e.g. `true`)
+* `keepalived_global_defs_raw`: [optional]: An optional list of raw parameters to add to the `global_defs` config section
 
 * `keepalived_vrrp_script_map`: [default: `{}`]: Script declarations
 * `keepalived_vrrp_script_map.key`: [required]: The identifier of the file (e.g. `check-haproxy`)
@@ -80,6 +81,7 @@ Set up the latest or a specific version of [Keepalived](http://www.keepalived.or
 * `keepalived_vrrp_instances.key.notify_master`: [optional]: Scripts that is invoked when a server changes state (to `MASTER`)
 * `keepalived_vrrp_instances.key.notify_master_user`: [optional]: Specify the user / group to run this script under (since `1.3.0`)
 * `keepalived_vrrp_instances.key.unicast_peer`: [optional]: IP address of aired unicast address (if you don't want to use multicast)
+* `keepalived_vrrp_instances.key.raw_options`: [optional]: An optional list of raw parameters to add to the vrrp instance
 
 #### Dependencies
 
@@ -117,6 +119,9 @@ None
 
         track_scripts:
           - chk_haproxy
+
+        raw_options:
+          - dont_track_primary
 ```
 
 #### License

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Set up the latest or a specific version of [Keepalived](http://www.keepalived.or
 * `keepalived_vrrp_instances.key.virtual_ipaddresses_excluded`: IP address block, which is not included in the VRRP packet itself, in order to support more than 20 ips
 * `keepalived_vrrp_instances.key.nopreempt`: [optional]: VRRP will normally preempt a lower priority machine when a higher priority machine comes online. This option allows the lower priority machine to maintain the master role, even when a higher priority machine comes back online. **NOTE:** For this to work, the initial state of this entry must be `BACKUP`
 * `keepalived_vrrp_instances.key.preempt_delay`: [optional]: Seconds after startup until preemption (if not disabled by `nopreempt`). Range: 0 (default) to 1000 **NOTE:** For this to work, the initial state of this entry must be BACKUP
-* `keepalived_vrrp_instances.key.track_scripts`: Scripts state we monitor
+* `keepalived_vrrp_instances.key.track_scripts`: [optional]: Scripts state we monitor
 
 * `keepalived_vrrp_instances.key.notify`: [optional]: Scripts that is invoked when a server changes state
 * `keepalived_vrrp_instances.key.notify_user`: [optional]: Specify the user / group to run this script under (since `1.3.0`, e.g. `'nobody nogroup'`)

--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -16,6 +16,9 @@ global_defs {
 {% if keepalived_global_defs_enable_script_security is defined and keepalived_global_defs_enable_script_security | bool %}
   enable_script_security
 {% endif %}
+{% for global_def_raw in keepalived_global_defs_raw | default([]) %}
+  {{ global_def_raw }}
+{% endfor %}
 }
 
 {% for key, value in keepalived_vrrp_scripts.items() %}
@@ -108,5 +111,8 @@ vrrp_instance {{ key }} {
 {% if value.notify_master is defined %}
   notify_master "{{ value.notify_master }}" {{ value.notify_master_user | default('') }}
 {% endif %}
+{% for raw_option in value.raw_options | default([]) %}
+  {{ raw_option }}
+{% endfor %}
 }
 {% endfor %}

--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -87,11 +87,13 @@ vrrp_instance {{ key }} {
   preempt_delay {{ value.preempt_delay }}
 {% endif %}
 
+{% if value.track_scripts is defined %}
   track_script {
 {% for track_script in value.track_scripts %}
     {{ track_script }}
 {% endfor %}
   }
+{% endif %}
 
 {% if value.unicast_peer is defined %}
   unicast_peer {


### PR DESCRIPTION
This allows us to inject arbitrary options into these portions of the keepalived config. Following the style used in your haproxy role for similar requirements.