### PR TITLE
add become statement to role use example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ None
 ---
 - hosts: all
   roles:
-    - keepalived
+    - role: keepalived
+      become: yes
   vars:
     keepalived_options:
       - name: log-detail


### PR DESCRIPTION
Hello,

thanks for your work on this module.

When trying it out I started with the example in the README.md,
however I immediately got a permission denied error on the first task (`allow binding non-local IP`)
because the individual tasks in the role do not specify `become` where needed.

Therefore, it is necessary to use the entire role with a blanket `become: yes` statement.
This was not in the example previously, so it didn't work as-is.

This is just a small correction so people can get started faster with your role, nobody likes red text in the console 😉 