### PR TITLE
Unicast / IPv6 Bind / SystemD Condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Set up the latest or a specific version of [Keepalived](http://www.keepalived.or
 * `keepalived_vrrp_instances.key.notify_fault_user`: [optional]: Specify the user / group to run this script under (since `1.3.0`)
 * `keepalived_vrrp_instances.key.notify_master`: [optional]: Scripts that is invoked when a server changes state (to `MASTER`)
 * `keepalived_vrrp_instances.key.notify_master_user`: [optional]: Specify the user / group to run this script under (since `1.3.0`)
-* `keepalived_vrrp_instances.key.unicast_peer`: [optional]: IP address of aired unicast address (if you don't want to use multicast)
+* `keepalived_vrrp_instances.key.unicast_peer`: [optional]: list of IP addresses if you want to override particapating unicast peers
+* `keepalived_vrrp_instances.key.unicast_src_ip`: [optional]: IP source address to use for multicast or unicast vrrp packets
+* `keepalived_vrrp_instances.key.vmac_xmit_base`: [default: `false`]: forces VRRP to use the physical interface MAC address as source when it sends its own packets.
 * `keepalived_vrrp_instances.key.raw_options`: [optional]: An optional list of raw parameters to add to the vrrp instance
 
 #### Dependencies

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,20 @@
 # tasks file
 ---
+- name: test if keepalived_vrrp_instances is set correctly
+  assert:
+    that:
+      - keepalived_vrrp_instances is defined
+      - keepalived_vrrp_instances is iterable
+    quiet: yes
+
+- name: Assert keepalived_vrrp_instances is a dictionary
+  assert:
+    that: ( keepalived_vrrp_instances is defined ) and ( keepalived_vrrp_instances | type_debug == "dict" )
+
+- name: Assert keepalived_vrrp_instances is a mapping
+  assert:
+    that: ( keepalived_vrrp_instances is defined ) and ( keepalived_vrrp_instances is mapping )
+
 - name: install dependencies
   apt:
     name: "{{ keepalived_dependencies }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,11 @@
 # tasks file
 ---
-- name: test if keepalived_vrrp_instances is set correctly
+- name: Assert keepalived_vrrp_instances is set correctly
   assert:
     that:
       - keepalived_vrrp_instances is defined
       - keepalived_vrrp_instances is iterable
     quiet: yes
-
-- name: Assert keepalived_vrrp_instances is a dictionary
-  assert:
-    that: ( keepalived_vrrp_instances is defined ) and ( keepalived_vrrp_instances | type_debug == "dict" )
-
-- name: Assert keepalived_vrrp_instances is a mapping
-  assert:
-    that: ( keepalived_vrrp_instances is defined ) and ( keepalived_vrrp_instances is mapping )
 
 - name: install dependencies
   apt:
@@ -39,9 +31,21 @@
     - keepalived-install
     - keepalived-install-additional
 
-- name: allow binding non-local IP
+- name: allow binding non-local IPv4
   sysctl:
     name: net.ipv4.ip_nonlocal_bind
+    value: "{{ keepalived_ip_nonlocal_bind | string }}"
+    reload: true
+    state: present
+  when: keepalived_ip_nonlocal_bind | bool
+  tags:
+    - configuration
+    - keepalived
+    - keepalived-ip-nonlocal-bind
+
+- name: allow binding non-local IPv6
+  sysctl:
+    name: net.ipv6.ip_nonlocal_bind
     value: "{{ keepalived_ip_nonlocal_bind | string }}"
     reload: true
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,15 @@
       - keepalived_vrrp_instances is iterable
     quiet: yes
 
+- name: Check if IPv6 is enabled
+  slurp:
+    src: /sys/module/ipv6/parameters/disable
+  register: _ipv6_disabled
+
+- name: Set ipv6_enabled fact
+  set_fact:
+    ipv6_enabled: "{{ not _ipv6_disabled.failed and '0' in (_ipv6_disabled.content | b64decode) }}"
+
 - name: install dependencies
   apt:
     name: "{{ keepalived_dependencies }}"
@@ -49,7 +58,7 @@
     value: "{{ keepalived_ip_nonlocal_bind | string }}"
     reload: true
     state: present
-  when: keepalived_ip_nonlocal_bind | bool
+  when: keepalived_ip_nonlocal_bind | bool and ipv6_enabled
   tags:
     - configuration
     - keepalived

--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -149,11 +149,15 @@ vrrp_instance {{ key }} {
   unicast_src_ip {{ value.unicast_src_ip }}
 {% endif %}
 
-{% if value.unicast_peer is defined %}
+{% if value.unicast_peer is iterable and value.unicast_peer is not string %}
   unicast_peer {
 {% for peer in value.unicast_peer %}
     {{ peer }}
 {% endfor %}
+  }
+{% elif value.unicast_peer is defined %}
+  unicast_peer {
+    {{ value.unicast_peer }}
   }
 {% endif %}
 

--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -141,9 +141,19 @@ vrrp_instance {{ key }} {
   }
 {% endif %}
 
+{% if value.vmac_xmit_base is defined and value.vmac_xmit_base | bool %}
+  vmac_xmit_base
+{% endif %}
+
+{% if value.unicast_src_ip is defined %}
+  unicast_src_ip {{ value.unicast_src_ip }}
+{% endif %}
+
 {% if value.unicast_peer is defined %}
   unicast_peer {
-    {{ value.unicast_peer }}
+{% for peer in value.unicast_peer %}
+    {{ peer }}
+{% endfor %}
   }
 {% endif %}
 

--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -149,15 +149,15 @@ vrrp_instance {{ key }} {
   unicast_src_ip {{ value.unicast_src_ip }}
 {% endif %}
 
-{% if value.unicast_peer is iterable and value.unicast_peer is not string %}
+{% if value.unicast_peer is defined %}
   unicast_peer {
+{% if value.unicast_peer is string %}
+    {{ value.unicast_peer }}
+{% else %}
 {% for peer in value.unicast_peer %}
     {{ peer }}
-{% endfor %}
-  }
-{% elif value.unicast_peer is defined %}
-  unicast_peer {
-    {{ value.unicast_peer }}
+{% endfor%}
+{% endif %}
   }
 {% endif %}
 

--- a/templates/etc/systemd/system/keepalived.service.j2
+++ b/templates/etc/systemd/system/keepalived.service.j2
@@ -4,6 +4,8 @@
 Description=Keepalived
 After=network-online.target
 Wants=network-online.target
+# Only start if there is a configuration file
+ConditionFileNotEmpty={{ keepalived_configuration_file }}
 
 [Service]
 Type=simple


### PR DESCRIPTION
Hello,
i really like your playbook to configure keepalived from upstream source. I have done some modifications that i would like to share:

- `keepalived_vrrp_instances.key.unicast_peer` can now be a list
- `keepalived_vrrp_instances.key.unicast_src_ip` allows to specify unicast source adress
- `keepalived_vrrp_instances.key.vmac_xmit_bas` instructs keepalived to use physical MAC
- allow binding of non local IPv6
- use `ConditionFileNotEmpty` to not start keepalived if no configuration file is present


Please tell me if you like or what i can adjust better ;-)