### PR TITLE
Tasks install additional should be idempotent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
     - keepalived
     - keepalived-install
     - keepalived-install-additional
+  when: keepalived_install | length>0
 
 - name: allow binding non-local IP
   sysctl:


### PR DESCRIPTION
Add a condition of the tasks otherwise, the tasks is not idempotent as it's output is changed (maybe due to emply list and update_cache):
```
TASK [oefenweb.keepalived : install additional] **********************************************************************************************************************************************
task path: /path/git/ansible/roles/oefenweb.keepalived/tasks/main.yml:3

changed: [servername] => {
    "cache_update_time": 1637566769,
    "cache_updated": true,
    "changed": true,
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoclean": false,
            "autoremove": false,
            "cache_valid_time": 3600,
            "deb": null,
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "fail_on_autoremove": false,
            "force": false,
            "force_apt_get": false,
            "install_recommends": null,
            "name": [],
            "only_upgrade": false,
            "package": [],
            "policy_rc_d": null,
            "purge": false,
            "state": "latest",
            "update_cache": true,
            "update_cache_retries": 5,
            "update_cache_retry_max_delay": 12,
            "upgrade": null
        }
    }
}
```