### PR TITLE
Fix vmac_xmit_base / Check Keepalived configuration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,7 +98,7 @@
     owner: root
     group: root
     mode: 0640
-    validate: "{{ keepalived_install_prefix }}/keepalived --use-file=%s --check --all-config --config-test"
+    validate: "{{ keepalived_install_prefix }}/keepalived --use-file=%s --check --config-test"
   notify: restart keepalived
   tags:
     - configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -118,6 +118,14 @@
     - keepalived
     - keepalived-scripts
 
+- name: check configuration file
+  command: |
+    keepalived -f {{ keepalived_configuration_file }} -C -e -t
+  changed_when: false
+  tags:
+    - configuration
+    - keepalived
+
 - include: service-upstart.yml
   when: ansible_service_mgr != 'systemd'
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,6 +98,7 @@
     owner: root
     group: root
     mode: 0640
+    validate: "{{ keepalived_install_prefix }}/keepalived --use-file=%s --check --all-config --config-test"
   notify: restart keepalived
   tags:
     - configuration
@@ -117,25 +118,6 @@
     - configuration
     - keepalived
     - keepalived-scripts
-
-# ignore_errors, so we can print pretty message afterwards
-- name: check configuration file
-  command: |
-    keepalived --use-file={{ keepalived_configuration_file }} --check --all-config --config-test
-  register: keepalived_config_test_result
-  changed_when: false
-  ignore_errors: true
-  tags:
-    - configuration
-    - keepalived
-
-- name: print error message from keepalived configuration config test
-  fail:
-    msg: "keepalived config-test failed with: {{ keepalived_config_test_result.stderr }}"
-  when: keepalived_config_test_result.rc != 0
-  tags:
-    - configuration
-    - keepalived
 
 - include: service-upstart.yml
   when: ansible_service_mgr != 'systemd'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -118,10 +118,21 @@
     - keepalived
     - keepalived-scripts
 
+# ignore_errors, so we can print pretty message afterwards
 - name: check configuration file
   command: |
-    keepalived -f {{ keepalived_configuration_file }} -C -e -t
+    keepalived --use-file={{ keepalived_configuration_file }} --check --all-config --config-test
+  register: keepalived_config_test_result
   changed_when: false
+  ignore_errors: true
+  tags:
+    - configuration
+    - keepalived
+
+- name: print error message from keepalived configuration config test
+  fail:
+    msg: "keepalived config-test failed with: {{ keepalived_config_test_result.stderr }}"
+  when: keepalived_config_test_result.rc != 0
   tags:
     - configuration
     - keepalived

--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -142,6 +142,7 @@ vrrp_instance {{ key }} {
 {% endif %}
 
 {% if value.vmac_xmit_base is defined and value.vmac_xmit_base | bool %}
+  use_vmac
   vmac_xmit_base
 {% endif %}
 


### PR DESCRIPTION
Hi, it's me again.
The mistake of missing `use_vmac` was my fault in the last PR, i added it now, 

I was working on some CI Stuff when i figured out, how to test keepalived configuration. In my case i want the playbook to fail if i provide any configuration that's not 100% valid.