### PR TITLE
Add virtual_routes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ when using `keepalived_install_method: native`
 * `keepalived_vrrp_instances.key.authentication.auth_pass`: Password string (up to 8 characters)
 * `keepalived_vrrp_instances.key.virtual_ipaddresses`: VRRP IP address block
 * `keepalived_vrrp_instances.key.virtual_ipaddresses_excluded`: IP address block, which is not included in the VRRP packet itself, in order to support more than 20 ips
+* `keepalived_vrrp_instances.key.virtual_routes:`: [optional]: List of virtual route added when the VIP is added
 * `keepalived_vrrp_instances.key.nopreempt`: [optional]: VRRP will normally preempt a lower priority machine when a higher priority machine comes online. This option allows the lower priority machine to maintain the master role, even when a higher priority machine comes back online. **NOTE:** For this to work, the initial state of this entry must be `BACKUP`
 * `keepalived_vrrp_instances.key.preempt_delay`: [optional]: Seconds after startup until preemption (if not disabled by `nopreempt`). Range: 0 (default) to 1000 **NOTE:** For this to work, the initial state of this entry must be BACKUP
 * `keepalived_vrrp_instances.key.track_interfaces`: [optional]: Interface states we monitor

--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -102,6 +102,14 @@ vrrp_instance {{ key }} {
 {% endfor %}
   }
 
+{% if value.virtual_routes %}
+  virtual_routes {
+{% for virtual_route in value.virtual_routes %}
+    {{ virtual_route }}
+{% endfor %}
+  }
+{% endif %}
+
 {% if value.virtual_ipaddresses_excluded is defined %}
   virtual_ipaddress_excluded {
 {% for virtual_ipaddress in value.virtual_ipaddresses_excluded | default([]) %}


### PR DESCRIPTION
Fix #52 :  

Can be used like this: ( i used it to routed outgoing traffic via the
VIP
```
keepalived_vrrp_instances:
...
    virtual_routes:
    - 'src IPADDR to 0.0.0.0/0 via GATEWAY dev ens3 metric 50'

```

pre-requisite of re-routing is to have a higher metric value in main network interface