### PR TITLE
 Add vrrp_sync_group option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ when using `keepalived_install_method: native`
 * `keepalived_vrrp_instances.key.vmac_xmit_base`: [default: `false`]: Forces VRRP to use the physical interface MAC address as source when it sends its own packets.
 * `keepalived_vrrp_instances.key.raw_options`: [optional]: An optional list of raw parameters to add to the vrrp instance
 
+* `keepalived_vrrp_sync_groups`: [default: `{}`]: VRRP group instance declarations
+* `keepalived_vrrp_sync_groups.key`: The name of the VRRP group instance
+* `keepalived_vrrp_sync_groups.key.instances:`: List of vrrp instances for this group
+* `keepalived_vrrp_sync_groups.notify_master`: [optional]: Scripts that is invoked when a server changes state (to `MASTER`)
+* `keepalived_vrrp_sync_groups.key.notify_backup`: [optional]: Scripts that is invoked when a server changes state (to `BACKUP`)
+* `keepalived_vrrp_sync_groups.key.notify_fault`: [optional]: Scripts that is invoked when a VRRP group server changes state (to `FAULT`)
+
 #### Dependencies
 
 None

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ when using `keepalived_install_method: native`
 * `keepalived_vrrp_sync_groups`: [default: `{}`]: VRRP group instance declarations
 * `keepalived_vrrp_sync_groups.key`: The name of the VRRP group instance
 * `keepalived_vrrp_sync_groups.key.instances:`: List of vrrp instances for this group
-* `keepalived_vrrp_sync_groups.notify_master`: [optional]: Scripts that is invoked when a server changes state (to `MASTER`)
-* `keepalived_vrrp_sync_groups.key.notify_backup`: [optional]: Scripts that is invoked when a server changes state (to `BACKUP`)
-* `keepalived_vrrp_sync_groups.key.notify_fault`: [optional]: Scripts that is invoked when a VRRP group server changes state (to `FAULT`)
+* `keepalived_vrrp_sync_groups.notify_master`: [optional]: Scripts that is invoked when VRRP group changes state (to `MASTER`)
+* `keepalived_vrrp_sync_groups.key.notify_backup`: [optional]: Scripts that is invoked when VRRP group changes state (to `BACKUP`)
+* `keepalived_vrrp_sync_groups.key.notify_fault`: [optional]: Scripts that is invoked when VRRP group changes state (to `FAULT`)
 
 #### Dependencies
 

--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -75,6 +75,27 @@ vrrp_track_process {{ key }} {
 }
 {% endfor %}
 
+{% if keepalived_vrrp_sync_groups is defined %}
+{% for name, sync_group in keepalived_vrrp_sync_groups.items() %}
+
+vrrp_sync_group {{ name }} {
+  group {
+    {% for instance in sync_group.instances -%}
+      {{ instance }}
+    {% endfor -%}
+  }
+{% if sync_group.notify_master is defined %}
+  notify_master "{{ sync_group.notify_master }}"
+{% endif %}
+{% if sync_group.notify_backup is defined %}
+  notify_backup "{{ sync_group.notify_backup }}"
+{% endif %}
+{% if sync_group.notify_fault is defined %}
+  notify_fault "{{ sync_group.notify_fault }}"
+{% endif %}
+}
+{% endfor %}
+{% endif %}
 {% for key, value in keepalived_vrrp_instances.items() | sort %}
 vrrp_instance {{ key }} {
   interface {{ value.interface }}


### PR DESCRIPTION
Add keepalive option vrrp_sync_group
* Documentation : https://keepalived.readthedocs.io/en/latest/configuration_synopsis.html

* Example of the vrrp_sync_group definition
```
vrrp_sync_group string {
    group {
        string
        string
    }
    notify_master /path_to_script/script_master.sh
        (or notify_master “ /path_to_script/script_master.sh <arg_list>”)
    notify_backup /path_to_script/script_backup.sh
        (or notify_backup “/path_to_script/script_backup.sh <arg_list>”)
    notify_fault /path_to_script/script_fault.sh
        (or notify_fault “ /path_to_script/script_fault.sh <arg_list>”)
}
```